### PR TITLE
Fix channel participant creation and rate limit

### DIFF
--- a/sdk/src/services/channel.ts
+++ b/sdk/src/services/channel.ts
@@ -27,10 +27,13 @@ export class ChannelService extends BaseService {
     // Derive channel PDA
     const [channelPDA] = findChannelPDA(wallet.publicKey, options.name, this.programId);
 
+    // Derive participant PDA for creator
+    const [participantPDA] = this.findParticipantPDA(channelPDA, agentPDA);
+
     const visibilityObj = this.convertChannelVisibility(options.visibility);
 
-    const tx = await program.methods
-      .createChannel(
+    const tx = await (program.methods as any)
+      .createChannelV2(
         options.name,
         options.description,
         visibilityObj,
@@ -38,8 +41,9 @@ export class ChannelService extends BaseService {
         new anchor.BN(options.feePerMessage)
       )
       .accounts({
+        agentAccount: agentPDA,
         channelAccount: channelPDA,
-        creatorAgent: agentPDA,
+        participantAccount: participantPDA,
         creator: wallet.publicKey,
         systemProgram: SystemProgram.programId,
       })


### PR DESCRIPTION
### **User description**
## Summary
- correct AGENT_ACCOUNT_SPACE size comment
- fix sliding-window logic in `broadcast_message`
- add creator as a participant using `createChannelV2`

## Testing
- `npm test`
- `cd sdk && bun test`
- `cd ../cli && bun test`


------
https://chatgpt.com/codex/tasks/task_e_6854ba35cd988330b375263c7916bf8b


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
• Fix channel creation to use `createChannelV2` with participant account
• Correct sliding-window rate limiting logic in message broadcasting
• Fix AGENT_ACCOUNT_SPACE size calculation comment
• Streamline participant stats update in broadcast message


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>channel.ts</strong><dd><code>Update channel creation to use V2 method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sdk/src/services/channel.ts

• Switch from <code>createChannel</code> to <code>createChannelV2</code> method<br> • Add <br>participant PDA derivation for channel creator<br> • Update account <br>structure with <code>agentAccount</code> and <code>participantAccount</code>


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/PoD-Protocol/pull/58/files#diff-c00881bcf4e9ddc342d2063cf732f94a265ea1ba22ee69f6bbaabbe802b684c5">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Fix rate limiting and account space calculation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

programs/pod-com/src/lib.rs

• Fix AGENT_ACCOUNT_SPACE size comment from 268 to 276 bytes<br> • <br>Refactor sliding-window rate limiting logic in <code>broadcast_message</code><br> • <br>Simplify message counter reset and participant stats update<br> • Remove <br>redundant participant stats update code


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/PoD-Protocol/pull/58/files#diff-6fac89918fe52f8d0337b99ba86941d3de77cd44fae89675946102e49106540e">+16/-22</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved message broadcasting rate limiting to ensure accurate enforcement of message intervals and limits.
- **Refactor**
  - Simplified and clarified rate limiting logic for message broadcasting.
  - Updated channel creation process to use enhanced account handling for participants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->