### PR TITLE
Fix EnhancedErrorHandler declaration

### DIFF
--- a/cli/src/utils/enhanced-error-handler.ts
+++ b/cli/src/utils/enhanced-error-handler.ts
@@ -224,6 +224,13 @@ export class EnhancedErrorHandler {
   private debugMode: boolean = false;
   private exitOnError: boolean = true;
 
+  /**
+   * Creates an instance of EnhancedErrorHandler.
+   * @param {object} [options={}] - Configuration options for the error handler.
+   * @param {boolean} [options.verbose=false] - If true, enables verbose error output.
+   * @param {boolean} [options.debug=false] - If true, enables debug mode for more detailed error information.
+   * @param {boolean} [options.exitOnError=true] - If true, the process will exit upon encountering an error.
+   */
   constructor(options: { verbose?: boolean; debug?: boolean; exitOnError?: boolean } = {}) {
     this.verbose = options.verbose || false;
     this.debugMode = options.debug || false;

--- a/cli/src/utils/enhanced-error-handler.ts
+++ b/cli/src/utils/enhanced-error-handler.ts
@@ -222,18 +222,6 @@ export const ERROR_TEMPLATES: Record<ErrorCode, Omit<ErrorDetails, 'code'>> = {
 export class EnhancedErrorHandler {
   private verbose: boolean = false;
   private debugMode: boolean = false;
-
-  constructor(options: { verbose?: boolean; debug?: boolean } = {}) {
-    this.verbose = options.verbose || false;
-    this.debugMode = options.debug || false;
-  }
-
-  /**
-   * Handle and display a PodError with full formatting
-   */
-export class EnhancedErrorHandler {
-  private verbose: boolean = false;
-  private debugMode: boolean = false;
   private exitOnError: boolean = true;
 
   constructor(options: { verbose?: boolean; debug?: boolean; exitOnError?: boolean } = {}) {
@@ -241,6 +229,7 @@ export class EnhancedErrorHandler {
     this.debugMode = options.debug || false;
     this.exitOnError = options.exitOnError ?? true;
   }
+
 
   public handleError(error: PodError | Error): void {
     if (error instanceof PodError) {
@@ -253,7 +242,6 @@ export class EnhancedErrorHandler {
       process.exit(1);
     }
   }
-}
 
   /**
    * Display a formatted PodError


### PR DESCRIPTION
### **User description**
## Summary
- consolidate duplicate `EnhancedErrorHandler` definitions
- keep final newline in `enhanced-error-handler.ts`
- run `bun run build` inside `cli` (fails due to unrelated TypeScript errors)

## Testing
- `bun run build`

------
https://chatgpt.com/codex/tasks/task_e_6854c81a3468833098efb8384136d5d5


___

### **PR Type**
Bug fix


___

### **Description**
• Fix duplicate `EnhancedErrorHandler` class declarations
• Consolidate constructor parameters and properties
• Add missing newline at end of file


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>enhanced-error-handler.ts</strong><dd><code>Consolidate duplicate class declarations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/src/utils/enhanced-error-handler.ts

• Remove duplicate <code>EnhancedErrorHandler</code> class declaration<br> • <br>Consolidate constructor with <code>exitOnError</code> parameter<br> • Fix missing <br>closing brace and add final newline


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/PoD-Protocol/pull/60/files#diff-8e288b92c51fbda5a1389cffd610ef1358e04ace7df8cdd81bcbc0acbfe282fc">+2/-14</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved internal structure by removing duplicate and incomplete class definitions. No changes to visible features or behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->