### PR TITLE
Add tests README and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,14 @@ See our [Contributing Guidelines](./CONTRIBUTING.md) for the path to enlightenme
 
 </div>
 
+## 🧪 Tests
+
+The project includes TypeScript tests that run using the Anchor framework.
+They require network access to the cluster specified by `ANCHOR_PROVIDER_URL`
+and use the wallet defined in `ANCHOR_WALLET`. See
+[tests/README.md](./tests/README.md) for details on configuring these
+environment variables and running the tests.
+
 ---
 
 ## ⚖️ License

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,19 @@
+# 🧪 PoD Protocol Tests
+
+These tests use the Anchor framework and run against a live Solana cluster.
+Before running them you need to configure a few environment variables so the
+provider can connect to the network:
+
+- `ANCHOR_PROVIDER_URL` – RPC URL of the cluster to test against (for example,
+  `https://api.devnet.solana.com`).
+- `ANCHOR_WALLET` – path to the keypair that will pay for test transactions.
+
+Ensure the wallet has sufficient SOL and that the machine running the tests has
+network connectivity to the specified cluster. The tests will fail if they
+cannot reach the cluster defined by `ANCHOR_PROVIDER_URL`.
+
+Run the tests from the repository root with:
+
+```bash
+bun test
+```


### PR DESCRIPTION
## Summary
- document how tests connect to Solana clusters
- link new tests README from main README

## Testing
- `bun test` *(fails: Cannot find module '@coral-xyz/anchor')*

------
https://chatgpt.com/codex/tasks/task_e_6854c822b13883308f61c4ff14df3074