### PR TITLE
Add CLI command matrix tester script

### DIFF
--- a/scripts/cli-command-matrix.ts
+++ b/scripts/cli-command-matrix.ts
@@ -166,13 +166,22 @@ async function main() {
   const results: Array<{ command: string; exit: number }> = [];
 
   for (const spec of specs) {
-    const combos = combinations(spec.options);
-    for (const combo of combos) {
-      const cmd = `${spec.base} ${combo.join(" ")}`.trim();
-      const res = await runCommand(cmd, globalOpts);
-      results.push({ command: cmd, exit: res.exitCode });
-    }
-  }
+    console.log(`Running ${specs.length} command groups...`);
+    let completed = 0;
+
+    for (const spec of specs) {
+      const combos = combinations(spec.options);
+      console.log(`Testing "${spec.base}" with ${combos.length} option combinations...`);
+  
+      for (const combo of combos) {
+        const cmd = `${spec.base} ${combo.join(" ")}`.trim();
+        const res = await runCommand(cmd, globalOpts);
+        results.push({ command: cmd, exit: res.exitCode });
+        completed++;
+        if (completed % 10 === 0) {
+          console.log(`Progress: ${completed} commands completed`);
+        }
+      }
 
   if (endpoint) {
     await runCommand("config clear-endpoint", globalOpts);

--- a/scripts/cli-command-matrix.ts
+++ b/scripts/cli-command-matrix.ts
@@ -180,9 +180,7 @@ const MAX_CONCURRENT = 5;
 for (const spec of specs) {
   const combos = combinations(spec.options);
   // Process in batches for controlled concurrency
-  let completed = 0; // Initialize completed counter
-  for (let i = 0; i < combos.length; i += MAX_CONCURRENT) {
-  // Process in batches for controlled concurrency
+    for (let i = 0; i < combos.length; i += MAX_CONCURRENT) {
   for (let i = 0; i < combos.length; i += MAX_CONCURRENT) {
     const batch = combos.slice(i, i + MAX_CONCURRENT);
     const promises = batch.map(async (combo) => {

--- a/scripts/cli-command-matrix.ts
+++ b/scripts/cli-command-matrix.ts
@@ -39,7 +39,7 @@ async function runCommand(cmd: string, globalOpts: string) {
     // Split into arguments to avoid command injection
     const args = [...globalOpts.split(' ').filter(Boolean), ...cmd.split(' ').filter(Boolean)];
     const { stdout, stderr } = await execAsync(
-      `node cli/dist/index.js ${args.map(arg => `"${arg.replace(/"/g, '\\"')}"`).join(' ')}`,
+      `node cli/dist/index.js ${args.map(arg => `"${arg.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`).join(' ')}`,
       { timeout: 30000 },
     );
     return { exitCode: 0, stdout, stderr };

--- a/scripts/cli-command-matrix.ts
+++ b/scripts/cli-command-matrix.ts
@@ -174,16 +174,16 @@ for (const spec of specs) {
   
       for (const combo of combos) {
         const cmd = `${spec.base} ${combo.join(" ")}`.trim();
-        const res = await runCommand(cmd, globalOpts);
-        results.push({ command: cmd, exit: res.exitCode });
-        completed++;
-        if (completed % 10 === 0) {
-          console.log(`Progress: ${completed} commands completed`);
-        }
+  
+    for (const combo of combos) {
+      const cmd = `${spec.base} ${combo.join(" ")}`.trim();
+      const res = await runCommand(cmd, globalOpts);
+      results.push({ command: cmd, exit: res.exitCode });
+      completed++;
+      if (completed % 10 === 0) {
+        console.log(`Progress: ${completed} commands completed`);
       }
-
-  if (endpoint) {
-    await runCommand("config clear-endpoint", globalOpts);
+    }
   }
 
   const data = [["Command", "Exit", "Result"]];

--- a/scripts/cli-command-matrix.ts
+++ b/scripts/cli-command-matrix.ts
@@ -172,19 +172,16 @@ for (const spec of specs) {
   const combos = combinations(spec.options);
   console.log(`Testing "${spec.base}" with ${combos.length} option combinations...`);
   
-      for (const combo of combos) {
-        const cmd = `${spec.base} ${combo.join(" ")}`.trim();
-  
-    for (const combo of combos) {
-      const cmd = `${spec.base} ${combo.join(" ")}`.trim();
-      const res = await runCommand(cmd, globalOpts);
-      results.push({ command: cmd, exit: res.exitCode });
-      completed++;
-      if (completed % 10 === 0) {
-        console.log(`Progress: ${completed} commands completed`);
-      }
+  for (const combo of combos) {
+    const cmd = `${spec.base} ${combo.join(" ")}`.trim();
+    const res = await runCommand(cmd, globalOpts);
+    results.push({ command: cmd, exit: res.exitCode });
+    completed++;
+    if (completed % 10 === 0) {
+      console.log(`Progress: ${completed} commands completed`);
     }
   }
+}
 
   const data = [["Command", "Exit", "Result"]];
   for (const r of results) {

--- a/scripts/cli-command-matrix.ts
+++ b/scripts/cli-command-matrix.ts
@@ -69,11 +69,13 @@ async function main() {
 
   const globalOpts =
     `--network devnet ${keypair ? `--keypair ${keypair}` : ""}`.trim();
-
-  if (endpoint) {
-    const result = await runCommand(`config set-endpoint ${endpoint}`, globalOpts);
-    if (result.exitCode !== 0) {
-      console.error(`Failed to set endpoint: ${result.stderr}`);
+if (endpoint && endpoint.trim()) {
+  const result = await runCommand(`config set-endpoint ${endpoint}`, globalOpts);
+  if (result.exitCode !== 0) {
+    console.error(`Failed to set endpoint: ${result.stderr}`);
+    process.exit(1);
+  }
+}
       process.exit(1);
     }
   }

--- a/scripts/cli-command-matrix.ts
+++ b/scripts/cli-command-matrix.ts
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+/**
+ * CLI command matrix tester for PoD Protocol
+ *
+ * Usage:
+ *   node scripts/cli-command-matrix.ts [--keypair path] [--endpoint url]
+ *
+ * The script enumerates common CLI commands with sample options,
+ * executes each combination using child_process.exec and summarizes
+ * exit codes. Provide a dummy keypair and optional devnet RPC endpoint
+ * for isolated testing.
+ */
+import { exec } from "child_process";
+import { promisify } from "util";
+import { table } from "table";
+
+const execAsync = promisify(exec);
+
+interface CommandSpec {
+  base: string;
+  options: string[];
+}
+
+function combinations(opts: string[]): string[][] {
+  const result: string[][] = [];
+  const total = 1 << opts.length;
+  for (let i = 0; i < total; i++) {
+    const combo: string[] = [];
+    for (let j = 0; j < opts.length; j++) {
+      if (i & (1 << j)) combo.push(opts[j]);
+    }
+    result.push(combo);
+  }
+  return result;
+}
+
+async function runCommand(cmd: string, globalOpts: string) {
+  try {
+    const { stdout, stderr } = await execAsync(
+      `node cli/dist/index.js ${globalOpts} ${cmd}`,
+      { timeout: 30000 },
+    );
+    return { exitCode: 0, stdout, stderr };
+  } catch (error: any) {
+    return {
+      exitCode: error.code ?? 1,
+      stdout: error.stdout ?? "",
+      stderr: error.stderr ?? error.message,
+    };
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  let keypair = "";
+  let endpoint = "";
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--keypair" && args[i + 1]) {
+      keypair = args[i + 1];
+      i++;
+    } else if (args[i] === "--endpoint" && args[i + 1]) {
+      endpoint = args[i + 1];
+      i++;
+    }
+  }
+
+  const globalOpts =
+    `--network devnet ${keypair ? `--keypair ${keypair}` : ""}`.trim();
+
+  if (endpoint) {
+    await runCommand(`config set-endpoint ${endpoint}`, globalOpts);
+  }
+
+  const specs: CommandSpec[] = [
+    { base: "status", options: [] },
+    {
+      base: "agent register",
+      options: ["--capabilities 1", "--metadata https://example.com/meta.json"],
+    },
+    {
+      base: "agent info 11111111111111111111111111111111111111111111",
+      options: [],
+    },
+    {
+      base: "agent update",
+      options: ["--capabilities 2", "--metadata https://example.com/new.json"],
+    },
+    { base: "agent list", options: ["--limit 1"] },
+
+    {
+      base: "message send",
+      options: [
+        "--recipient 11111111111111111111111111111111111111111111",
+        "--payload hello",
+        "--type text",
+      ],
+    },
+    { base: "message info 1", options: [] },
+    { base: "message status", options: ["--message 1", "--status delivered"] },
+    {
+      base: "message list",
+      options: [
+        "--agent 11111111111111111111111111111111111111111111",
+        "--limit 1",
+        "--filter delivered",
+      ],
+    },
+
+    {
+      base: "channel create",
+      options: ["--name test", "--description example", "--visibility public"],
+    },
+    {
+      base: "channel info 11111111111111111111111111111111111111111111",
+      options: [],
+    },
+    { base: "channel list", options: ["--limit 1"] },
+    {
+      base: "channel join 11111111111111111111111111111111111111111111",
+      options: [],
+    },
+    {
+      base: "channel leave 11111111111111111111111111111111111111111111",
+      options: [],
+    },
+    {
+      base: 'channel broadcast 11111111111111111111111111111111111111111111 "hi"',
+      options: ["--type text"],
+    },
+    {
+      base: "channel invite 11111111111111111111111111111111111111111111 11111111111111111111111111111111111111111111",
+      options: [],
+    },
+    {
+      base: "channel participants 11111111111111111111111111111111111111111111",
+      options: ["--limit 1"],
+    },
+    {
+      base: "channel messages 11111111111111111111111111111111111111111111",
+      options: ["--limit 1"],
+    },
+
+    {
+      base: "escrow deposit",
+      options: [
+        "--channel 11111111111111111111111111111111111111111111",
+        "--lamports 1000",
+      ],
+    },
+    {
+      base: "escrow withdraw",
+      options: [
+        "--channel 11111111111111111111111111111111111111111111",
+        "--lamports 1000",
+      ],
+    },
+    {
+      base: "escrow balance",
+      options: ["--channel 11111111111111111111111111111111111111111111"],
+    },
+    { base: "escrow list", options: ["--limit 1"] },
+
+    { base: "config show", options: [] },
+  ];
+
+  const results: Array<{ command: string; exit: number }> = [];
+
+  for (const spec of specs) {
+    const combos = combinations(spec.options);
+    for (const combo of combos) {
+      const cmd = `${spec.base} ${combo.join(" ")}`.trim();
+      const res = await runCommand(cmd, globalOpts);
+      results.push({ command: cmd, exit: res.exitCode });
+    }
+  }
+
+  if (endpoint) {
+    await runCommand("config clear-endpoint", globalOpts);
+  }
+
+  const data = [["Command", "Exit", "Result"]];
+  for (const r of results) {
+    data.push([r.command, String(r.exit), r.exit === 0 ? "PASS" : "FAIL"]);
+  }
+  console.log(table(data));
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/cli-command-matrix.ts
+++ b/scripts/cli-command-matrix.ts
@@ -69,7 +69,11 @@ async function main() {
     `--network devnet ${keypair ? `--keypair ${keypair}` : ""}`.trim();
 
   if (endpoint) {
-    await runCommand(`config set-endpoint ${endpoint}`, globalOpts);
+    const result = await runCommand(`config set-endpoint ${endpoint}`, globalOpts);
+    if (result.exitCode !== 0) {
+      console.error(`Failed to set endpoint: ${result.stderr}`);
+      process.exit(1);
+    }
   }
 
   const specs: CommandSpec[] = [

--- a/scripts/cli-command-matrix.ts
+++ b/scripts/cli-command-matrix.ts
@@ -75,9 +75,6 @@ if (endpoint && endpoint.trim()) {
   if (result.exitCode !== 0) {
     console.error(`Failed to set endpoint: ${result.stderr}`);
     process.exit(1);
-  }
-}
-      process.exit(1);
     }
   }
 

--- a/scripts/cli-command-matrix.ts
+++ b/scripts/cli-command-matrix.ts
@@ -168,9 +168,6 @@ async function main() {
 console.log(`Running ${specs.length} command groups...`);
 let completed = 0;
 
-console.log(`Running ${specs.length} command groups...`);
-let completed = 0;
-
 for (const spec of specs) {
   const combos = combinations(spec.options);
   console.log(`Testing "${spec.base}" with ${combos.length} option combinations...`);

--- a/scripts/cli-command-matrix.ts
+++ b/scripts/cli-command-matrix.ts
@@ -178,8 +178,9 @@ console.log(`Running ${specs.length} command groups...`);
 const MAX_CONCURRENT = 5;
 for (const spec of specs) {
   const combos = combinations(spec.options);
-  console.log(`Testing "${spec.base}" with ${combos.length} option combinations...`);
-  
+  // Process in batches for controlled concurrency
+  let completed = 0; // Initialize completed counter
+  for (let i = 0; i < combos.length; i += MAX_CONCURRENT) {
   // Process in batches for controlled concurrency
   for (let i = 0; i < combos.length; i += MAX_CONCURRENT) {
     const batch = combos.slice(i, i + MAX_CONCURRENT);

--- a/scripts/cli-command-matrix.ts
+++ b/scripts/cli-command-matrix.ts
@@ -190,9 +190,7 @@ for (const spec of specs) {
       completed++;
       if (completed % 10 === 0) {
         console.log(`Progress: ${completed} commands completed`);
-      }
-    });
-    await Promise.all(promises);
+  }
   }
     }
   }

--- a/scripts/cli-command-matrix.ts
+++ b/scripts/cli-command-matrix.ts
@@ -168,12 +168,12 @@ async function main() {
 console.log(`Running ${specs.length} command groups...`);
 let completed = 0;
 
-for (const spec of specs) {
-    let completed = 0;
+console.log(`Running ${specs.length} command groups...`);
+let completed = 0;
 
-    for (const spec of specs) {
-      const combos = combinations(spec.options);
-      console.log(`Testing "${spec.base}" with ${combos.length} option combinations...`);
+for (const spec of specs) {
+  const combos = combinations(spec.options);
+  console.log(`Testing "${spec.base}" with ${combos.length} option combinations...`);
   
       for (const combo of combos) {
         const cmd = `${spec.base} ${combo.join(" ")}`.trim();

--- a/scripts/cli-command-matrix.ts
+++ b/scripts/cli-command-matrix.ts
@@ -38,8 +38,9 @@ async function runCommand(cmd: string, globalOpts: string) {
   try {
     // Split into arguments to avoid command injection
     const args = [...globalOpts.split(' ').filter(Boolean), ...cmd.split(' ').filter(Boolean)];
-    const { stdout, stderr } = await execAsync(
-      `node cli/dist/index.js ${args.map(arg => `"${arg.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`).join(' ')}`,
+    const { stdout, stderr } = await promisify(require('child_process').execFile)(
+      'node', 
+      ['cli/dist/index.js', ...args],
       { timeout: 30000 },
     );
     return { exitCode: 0, stdout, stderr };

--- a/scripts/cli-command-matrix.ts
+++ b/scripts/cli-command-matrix.ts
@@ -43,11 +43,10 @@ async function runCommand(cmd: string, globalOpts: string) {
     return { exitCode: 0, stdout, stderr };
   } catch (error: any) {
     return {
-      exitCode: error.code ?? 1,
+      exitCode: error.signal === 'SIGTERM' ? 124 : error.code ?? 1,
       stdout: error.stdout ?? "",
-      stderr: error.stderr ?? error.message,
+      stderr: error.signal === 'SIGTERM' ? 'Command timed out' : error.stderr ?? error.message,
     };
-  }
 }
 
 async function main() {

--- a/scripts/cli-command-matrix.ts
+++ b/scripts/cli-command-matrix.ts
@@ -165,9 +165,10 @@ async function main() {
   ];
 
   const results: Array<{ command: string; exit: number }> = [];
+console.log(`Running ${specs.length} command groups...`);
+let completed = 0;
 
-  for (const spec of specs) {
-    console.log(`Running ${specs.length} command groups...`);
+for (const spec of specs) {
     let completed = 0;
 
     for (const spec of specs) {

--- a/scripts/cli-command-matrix.ts
+++ b/scripts/cli-command-matrix.ts
@@ -47,6 +47,7 @@ async function runCommand(cmd: string, globalOpts: string) {
       stdout: error.stdout ?? "",
       stderr: error.signal === 'SIGTERM' ? 'Command timed out' : error.stderr ?? error.message,
     };
+  }
 }
 
 async function main() {

--- a/scripts/cli-command-matrix.ts
+++ b/scripts/cli-command-matrix.ts
@@ -36,8 +36,10 @@ function combinations(opts: string[]): string[][] {
 
 async function runCommand(cmd: string, globalOpts: string) {
   try {
+    // Split into arguments to avoid command injection
+    const args = [...globalOpts.split(' ').filter(Boolean), ...cmd.split(' ').filter(Boolean)];
     const { stdout, stderr } = await execAsync(
-      `node cli/dist/index.js ${globalOpts} ${cmd}`,
+      `node cli/dist/index.js ${args.map(arg => `"${arg.replace(/"/g, '\\"')}"`).join(' ')}`,
       { timeout: 30000 },
     );
     return { exitCode: 0, stdout, stderr };


### PR DESCRIPTION
### **User description**
## Summary
- add `scripts/cli-command-matrix.ts` to exercise CLI commands

## Testing
- `npm test --silent` *(fails: expect(received).toBe(expected))*

------
https://chatgpt.com/codex/tasks/task_e_6854ced0ae208330b7d60224e08b77e6


___

### **PR Type**
Tests


___

### **Description**
• Add CLI command matrix testing script for comprehensive command validation
• Implement combinatorial testing for all CLI commands with various options
• Include automated execution and result reporting with pass/fail status


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cli-command-matrix.ts</strong><dd><code>CLI command matrix testing implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/cli-command-matrix.ts

• Create comprehensive CLI testing script with 192 lines of code<br> • <br>Implement combinatorial option testing for all CLI commands<br> • Add <br>automated execution with timeout handling and result reporting<br> • <br>Include support for custom keypair and endpoint configuration


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/PoD-Protocol/pull/68/files#diff-f540f1eb642a93f860c631a988e54dc06703fb02eb5a8bd96b9578b81ba2e392">+192/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>