### PR TITLE
Add CLI command matrix tester script

### DIFF
--- a/scripts/cli-command-matrix.ts
+++ b/scripts/cli-command-matrix.ts
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+/**
+ * CLI command matrix tester for PoD Protocol
+ *
+ * Usage:
+ *   node scripts/cli-command-matrix.ts [--keypair path] [--endpoint url]
+ *
+ * The script enumerates common CLI commands with sample options,
+ * executes each combination using child_process.exec and summarizes
+ * exit codes. Provide a dummy keypair and optional devnet RPC endpoint
+ * for isolated testing.
+ */
+import { exec } from "child_process";
+import { promisify } from "util";
+import { table } from "table";
+
+const execAsync = promisify(exec);
+
+interface CommandSpec {
+  base: string;
+  options: string[];
+}
+
+function combinations(opts: string[]): string[][] {
+  const result: string[][] = [];
+  const total = 1 << opts.length;
+  for (let i = 0; i < total; i++) {
+    const combo: string[] = [];
+    for (let j = 0; j < opts.length; j++) {
+      if (i & (1 << j)) combo.push(opts[j]);
+    }
+    result.push(combo);
+  }
+  return result;
+}
+
+async function runCommand(cmd: string, globalOpts: string) {
+  try {
+    const { stdout, stderr } = await execAsync(
+      `node cli/dist/index.js ${globalOpts} ${cmd}`,
+      { timeout: 30000 },
+    );
+    return { exitCode: 0, stdout, stderr };
+  } catch (error: any) {
+    return {
+      exitCode: error.code ?? 1,
+      stdout: error.stdout ?? "",
+      stderr: error.stderr ?? error.message,
+    };
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  let keypair = "";
+  let endpoint = "";
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--keypair" && args[i + 1]) {
+      keypair = args[i + 1];
+      i++;
+    } else if (args[i] === "--endpoint" && args[i + 1]) {
+      endpoint = args[i + 1];
+      i++;
+    }
+  }
+
+  const globalOpts =
+    `--network devnet ${keypair ? `--keypair ${keypair}` : ""}`.trim();
+
+  if (endpoint) {
+    await runCommand(`config set-endpoint ${endpoint}`, globalOpts);
+  }
+
+  const specs: CommandSpec[] = [
+    { base: "status", options: [] },
+    {
+      base: "agent register",
+      options: ["--capabilities 1", "--metadata https://example.com/meta.json"],
+    },
+    {
+      base: "agent info 11111111111111111111111111111111111111111111",
+      options: [],
+    },
+    {
+      base: "agent update",
+      options: ["--capabilities 2", "--metadata https://example.com/new.json"],
+    },
+    { base: "agent list", options: ["--limit 1"] },
+
+    {
+      base: "message send",
+      options: [
+        "--recipient 11111111111111111111111111111111111111111111",
+        "--payload hello",
+        "--type text",
+      ],
+    },
+    { base: "message info 1", options: [] },
+    { base: "message status", options: ["--message 1", "--status delivered"] },
+    {
+      base: "message list",
+      options: [
+        "--agent 11111111111111111111111111111111111111111111",
+        "--limit 1",
+        "--filter delivered",
+      ],
+    },
+
+    {
+      base: "channel create",
+      options: ["--name test", "--description example", "--visibility public"],
+    },
+    {
+      base: "channel info 11111111111111111111111111111111111111111111",
+      options: [],
+    },
+    { base: "channel list", options: ["--limit 1"] },
+    {
+      base: "channel join 11111111111111111111111111111111111111111111",
+      options: [],
+    },
+    {
+      base: "channel leave 11111111111111111111111111111111111111111111",
+      options: [],
+    },
+    {
+      base: 'channel broadcast 11111111111111111111111111111111111111111111 "hi"',
+      options: ["--type text"],
+    },
+    {
+      base: "channel invite 11111111111111111111111111111111111111111111 11111111111111111111111111111111111111111111",
+      options: [],
+    },
+    {
+      base: "channel participants 11111111111111111111111111111111111111111111",
+      options: ["--limit 1"],
+    },
+    {
+      base: "channel messages 11111111111111111111111111111111111111111111",
+      options: ["--limit 1"],
+    },
+
+    {
+      base: "escrow deposit",
+      options: [
+        "--channel 11111111111111111111111111111111111111111111",
+        "--lamports 1000",
+      ],
+    },
+    {
+      base: "escrow withdraw",
+      options: [
+        "--channel 11111111111111111111111111111111111111111111",
+        "--lamports 1000",
+      ],
+    },
+    {
+      base: "escrow balance",
+      options: ["--channel 11111111111111111111111111111111111111111111"],
+    },
+    { base: "escrow list", options: ["--limit 1"] },
+
+    { base: "config show", options: [] },
+  ];
+
+  const results: Array<{ command: string; exit: number }> = [];
+
+  for (const spec of specs) {
+    const combos = combinations(spec.options);
+    for (const combo of combos) {
+      const cmd = `${spec.base} ${combo.join(" ")}`.trim();
+      const res = await runCommand(cmd, globalOpts);
+      results.push({ command: cmd, exit: res.exitCode });
+    }
+  }
+
+  if (endpoint) {
+    await runCommand("config clear-endpoint", globalOpts);
+  }
+
+  const data = [["Command", "Exit", "Result"]];
+  for (const r of results) {
+    data.push([r.command, String(r.exit), r.exit === 0 ? "PASS" : "FAIL"]);
+  }
+  console.log(table(data));
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
### **User description**
## Summary
- add `scripts/cli-command-matrix.ts` to exercise CLI commands

## Testing
- `npm test --silent` *(fails: expect(received).toBe(expected))*

------
https://chatgpt.com/codex/tasks/task_e_6854ced0ae208330b7d60224e08b77e6


___

### **PR Type**
Tests


___

### **Description**
• Add comprehensive CLI command matrix testing script
• Test all CLI commands with option combinations
• Generate tabular test results with pass/fail status
• Support configurable keypair and endpoint parameters


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cli-command-matrix.ts</strong><dd><code>CLI command matrix testing implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/cli-command-matrix.ts

• Creates new TypeScript script for testing CLI commands<br> • Implements <br>combinatorial testing of command options<br> • Executes commands via <br>child_process and captures results<br> • Generates formatted table output <br>with pass/fail status


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/PoD-Protocol/pull/70/files#diff-f540f1eb642a93f860c631a988e54dc06703fb02eb5a8bd96b9578b81ba2e392">+192/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a CLI testing tool that runs a comprehensive set of commands with various option combinations and summarizes results in a formatted table.
	- Supports custom keypair files and RPC endpoint configuration for flexible testing.
	- Displays pass/fail status for each command tested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->