### PR TITLE
Handle dry-run wallet skip

### DIFF
--- a/cli/src/commands/escrow.ts
+++ b/cli/src/commands/escrow.ts
@@ -212,16 +212,6 @@ export class EscrowCommands {
       lamports: options.lamports,
       all: options.all,
     });
-    const spinner = createSpinner("Depositing to escrow...");
-    if (
-      globalOpts.dryRun &&
-      handleDryRun(globalOpts, spinner, "Escrow deposit", {
-        Channel: channelId,
-        Amount: `${lamportsToSol(amount)} SOL (${amount} lamports)`,
-      })
-    ) {
-      return;
-    }
     const channelKey = validatePublicKey(channelId, "channel ID");
     if (
       handleDryRun(globalOpts, spinner, "Escrow deposit", {

--- a/cli/src/commands/escrow.ts
+++ b/cli/src/commands/escrow.ts
@@ -212,8 +212,17 @@ export class EscrowCommands {
       lamports: options.lamports,
       all: options.all,
     });
-    const channelKey = validatePublicKey(channelId, "channel ID");
     const spinner = createSpinner("Depositing to escrow...");
+    if (
+      globalOpts.dryRun &&
+      handleDryRun(globalOpts, spinner, "Escrow deposit", {
+        Channel: channelId,
+        Amount: `${lamportsToSol(amount)} SOL (${amount} lamports)`,
+      })
+    ) {
+      return;
+    }
+    const channelKey = validatePublicKey(channelId, "channel ID");
     if (
       handleDryRun(globalOpts, spinner, "Escrow deposit", {
         Channel: channelId,

--- a/cli/src/commands/message/handlers.ts
+++ b/cli/src/commands/message/handlers.ts
@@ -46,10 +46,23 @@ export class MessageHandlers {
       throw new ValidationError("Recipient and payload are required");
     }
 
-    const recipientKey = MessageValidators.validateRecipient(recipient);
     const validatedPayload = MessageValidators.validateMessageContent(payload);
 
     const spinner = createSpinner("Sending message...");
+
+    if (this.context.globalOpts.dryRun) {
+      handleDryRun(this.context.globalOpts, spinner, "Message send", {
+        Recipient: recipient,
+        Type: messageType,
+        Content:
+          validatedPayload.slice(0, 100) +
+          (validatedPayload.length > 100 ? "..." : ""),
+        "Custom Value": customValue > 0 ? customValue : "N/A",
+      });
+      return;
+    }
+
+    const recipientKey = MessageValidators.validateRecipient(recipient);
 
     if (
       handleDryRun(this.context.globalOpts, spinner, "Message send", {

--- a/cli/src/utils/shared.ts
+++ b/cli/src/utils/shared.ts
@@ -38,8 +38,14 @@ export function createCommandHandler<T extends any[]>(
       const globalOpts = getCommandOpts(cmd);
       const commandArgs = args.slice(0, -1) as T;
       
-      const wallet = getWallet(globalOpts.keypair);
-      const keypair = getKeypair(globalOpts.keypair);
+      let wallet: ReturnType<typeof getWallet> | undefined;
+      let keypair: ReturnType<typeof getKeypair> | undefined;
+
+      if (!globalOpts.dryRun) {
+        wallet = getWallet(globalOpts.keypair);
+        keypair = getKeypair(globalOpts.keypair);
+      }
+
       const client = await createClient(globalOpts.network, wallet);
       await handler(client, keypair, globalOpts, ...commandArgs);
     } catch (error: any) {
@@ -73,7 +79,7 @@ export function handleDryRun(
  * Create spinner with consistent messaging
  */
 export function createSpinner(message: string): Ora {
-  return ora(message).start();
+  return ora({ text: message, stream: process.stdout }).start();
 }
 
 /**


### PR DESCRIPTION
### **User description**
## Summary
- avoid wallet/keypair creation in dry-run mode
- ensure CLI spinner output uses stdout
- short-circuit validations for dry-run for message send and escrow deposit

## Testing
- `bun run test`

------
https://chatgpt.com/codex/tasks/task_e_68550dedd50c8330a460ef6363929708


___

### **PR Type**
Enhancement


___

### **Description**
• Add dry-run support without wallet/keypair creation
• Move validation checks after dry-run handling
• Fix CLI spinner output to use stdout
• Short-circuit operations for dry-run mode


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>escrow.ts</strong><dd><code>Move dry-run handling before validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/src/commands/escrow.ts

• Move dry-run check before <code>validatePublicKey</code> call<br> • Early return for <br>dry-run mode to skip validation


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/PoD-Protocol/pull/73/files#diff-06ad6f3292193092acc587b720f1569441a7da378928a6cd71e551944232d4d9">+10/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>handlers.ts</strong><dd><code>Add early dry-run validation bypass</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/src/commands/message/handlers.ts

• Add early dry-run check before recipient validation<br> • Move <br><code>validateRecipient</code> call after dry-run handling<br> • Return early for <br>dry-run mode


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/PoD-Protocol/pull/73/files#diff-6e654d3669a82fb9b794154870907eec992dff51b017e9e5709a389db612893d">+14/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>shared.ts</strong><dd><code>Conditional wallet creation and spinner fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/src/utils/shared.ts

• Make wallet and keypair creation conditional on dry-run mode<br> • Skip <br>wallet/keypair initialization when <code>dryRun</code> is true<br> • Configure spinner <br>to use stdout stream


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/PoD-Protocol/pull/73/files#diff-62f7ac9e955b7ede6803c49da0b894cb4eef97b9ce6bec597545bed1c7e67bbd">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>