### PR TITLE
Implement analytics InfluxDB and discovery helpers

### DIFF
--- a/sdk/src/services/analytics.ts
+++ b/sdk/src/services/analytics.ts
@@ -22,14 +22,19 @@ import {
 
 const provider = AnchorProvider.env();
 const program = new Program(idl as any, PROGRAM_ID, provider);
-const discoMap: Record<string, string> = {};
-if (Array.isArray((idl as any).accounts)) {
-  for (const acc of (idl as any).accounts) {
-    discoMap[acc.name] = utils.bytes.bs58.encode(
-      utils.accountDiscriminator(acc.name),
-    );
+function getAccountDiscriminators(idl: any): Record<string, string> {
+  const discoMap: Record<string, string> = {};
+  if (Array.isArray(idl.accounts)) {
+    for (const acc of idl.accounts) {
+      discoMap[acc.name] = utils.bytes.bs58.encode(
+        utils.accountDiscriminator(acc.name),
+      );
+    }
   }
+  return discoMap;
 }
+
+const discoMap: Record<string, string> = getAccountDiscriminators(idl as any);
 
 const influx = new InfluxDB({
   url: process.env.INFLUX_URL || "",

--- a/sdk/src/services/discovery.ts
+++ b/sdk/src/services/discovery.ts
@@ -846,9 +846,15 @@ export class DiscoveryService extends BaseService {
 export async function getChannelParticipants(
   channelId: string,
 ): Promise<string[]> {
-  const result = await db.query(
-    'SELECT participant_pubkey FROM channel_participants_index WHERE channel_id = $1',
-    [channelId],
-  );
-  return result.rows.map((r) => r.participant_pubkey);
+  try {
+    const result = await db.query(
+      'SELECT participant_pubkey FROM channel_participants_index WHERE channel_id = $1',
+      [channelId],
+    );
+    return result.rows.map((r) => r.participant_pubkey);
+  } catch (error) {
+    console.error("Failed to get channel participants:", error);
+    return []; // Or throw the error, depending on desired behavior
+  }
+}
 }


### PR DESCRIPTION
## Summary
- connect analytics service to InfluxDB and Anchor IDL
- compute account discriminators dynamically
- add Influx query for peak usage
- provide capability filtering helper and DB channel participants lookup

## Testing
- `npm test` *(fails: Unknown env config "http-proxy")*

------
https://chatgpt.com/codex/tasks/task_e_6857e76fab2c833095912729efdd308b

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Implement support for InfluxDB in the analytics service, update discovery service with database integration, and add filtering helpers.

### Why are these changes being made?

The changes leverage InfluxDB to record and retrieve time-series data for analytics on agent activities, enhancing accurate tracking and reporting of peak usage times. The discovery service integrates a Postgres database pool for more efficient data operations and includes new filtering functionalities to refine search results based on capabilities, ensuring better performance and scalability of the system.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->