### PR TITLE
Add anchor install docs and pretest dependency check

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,18 @@ For full details on ZK compression commands and configuration, see [ZK-COMPRESSI
 
 ````
 
+### Install `@coral-xyz/anchor`
+
+Many of the development scripts and tests rely on the Anchor JavaScript library. If it isn't installed yet, add it with your preferred package manager:
+
+```bash
+bun add -D @coral-xyz/anchor
+# or
+yarn add -D @coral-xyz/anchor
+```
+
+This provides the `AnchorProvider` and other helpers used throughout the SDK and test suite.
+
 ### The Developer's Path to Enlightenment
 
 ```typescript

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "ci:build": "yarn run build:verify && yarn run build:all",
     "ci:test": "yarn run test:all && yarn run lint:all",
     "validate:workflows": "node scripts/validate-workflows.js",
-    "pretest": "yarn run build:verify",
+    "pretest": "node scripts/check-dependencies.js && yarn run build:verify",
     "prepublishOnly": "yarn run production:test && yarn run build:all"
   },
   "keywords": [

--- a/scripts/check-dependencies.js
+++ b/scripts/check-dependencies.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+
+function checkPackage(pkg) {
+  try {
+    require.resolve(pkg);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const missing = [];
+if (!checkPackage('@coral-xyz/anchor')) {
+  missing.push('@coral-xyz/anchor');
+}
+
+if (missing.length > 0) {
+  console.error(`❌ Missing dependencies: ${missing.join(', ')}`);
+  console.error('Install them with `bun add -D @coral-xyz/anchor` or `yarn add -D @coral-xyz/anchor`.');
+  process.exit(1);
+} else {
+  console.log('✅ All required packages are installed.');
+}

--- a/scripts/setup-package-managers.js
+++ b/scripts/setup-package-managers.js
@@ -38,6 +38,15 @@ function checkPackageManager(manager) {
   }
 }
 
+function checkNodePackage(pkg) {
+  try {
+    require.resolve(pkg);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 async function main() {
   console.log('🔧 Setting up package managers for PoD Protocol...');
   
@@ -54,12 +63,20 @@ async function main() {
   
   console.log('📦 Installing dependencies with Yarn (for Anchor compatibility)...');
   runCommand('yarn install', { exitOnError: false });
-  
+
+  if (!checkNodePackage('@coral-xyz/anchor')) {
+    console.log('📦 Installing @coral-xyz/anchor...');
+    runCommand('yarn add -D @coral-xyz/anchor', { exitOnError: false });
+  }
+
   // Install workspace dependencies with Bun for faster builds
   if (hasBun) {
     console.log('📦 Installing workspace dependencies with Bun...');
     runCommand('cd sdk && bun install', { exitOnError: false });
     runCommand('cd cli && bun install', { exitOnError: false });
+    if (!checkNodePackage('@coral-xyz/anchor')) {
+      runCommand('bun add -D @coral-xyz/anchor', { exitOnError: false });
+    }
   }
   
   console.log('✅ Package manager setup complete!');


### PR DESCRIPTION
## Summary
- document installing `@coral-xyz/anchor`
- check for missing packages before tests
- automatically install `@coral-xyz/anchor` in setup script

## Testing
- `bun install --no-progress`
- `node scripts/check-dependencies.js`
- `bun test` *(fails: missing env vars and network access)*

------
https://chatgpt.com/codex/tasks/task_e_6858a14ada1c8330bae3fe285c375444