### PR TITLE
chore(deps): bump Light Protocol crates

### DIFF
--- a/docs/guides/ZK-COMPRESSION-README.md
+++ b/docs/guides/ZK-COMPRESSION-README.md
@@ -69,10 +69,10 @@ pub struct CompressedChannelParticipant {
 #### Dependencies Added:
 ```toml
 [dependencies]
-light-compressed-token = { version = "1.0.0", default-features = false }
-light-system-program = { version = "1.0.0", default-features = false }
-light-hasher = { version = "1.0.0", default-features = false }
-light-utils = { version = "1.0.0", default-features = false }
+light-compressed-token = { version = "2.0.0", default-features = false }
+light-system-program = { version = "1.2.0", default-features = false }
+light-hasher = { version = "3.1.0", default-features = false }
+light-utils = { version = "1.1.0", default-features = false }
 ```
 
 ### 2. TypeScript SDK

--- a/docs/guides/ZK-COMPRESSION-README.md
+++ b/docs/guides/ZK-COMPRESSION-README.md
@@ -73,6 +73,7 @@ light-compressed-token = { version = "2.0.0", default-features = false }
 light-system-program = { version = "1.2.0", default-features = false }
 light-hasher = { version = "3.1.0", default-features = false }
 light-utils = { version = "1.1.0", default-features = false }
+light-heap = { version = "1.1.0", default-features = false }
 ```
 
 ### 2. TypeScript SDK

--- a/programs/pod-com/Cargo.toml
+++ b/programs/pod-com/Cargo.toml
@@ -25,11 +25,11 @@ anchor-lang = { version = "=0.29.0", default-features = false, features = ["init
 solana-program = { version = "=1.18.22", default-features = false }
 
 # Light Protocol ZK Compression dependencies - using older compatible versions
-light-compressed-token = { version = "1.1.0", features = ["cpi", "idl-build"] }
-light-system-program = { version = "1.1.0", features = ["cpi", "idl-build"] }
-light-hasher = { version = "1.1.0" }
+light-compressed-token = { version = "2.0.0", features = ["cpi", "idl-build"] }
+light-system-program = { version = "1.2.0", features = ["cpi", "idl-build"] }
+light-hasher = { version = "3.1.0" }
 light-utils = { version = "1.1.0" }
-light-heap = { version = "1.1.0" }
+light-heap = { version = "2.0.0" }
 
 # Spl dependencies (commented out as they're optional)
 # spl-token = { version = "=4.0.0", optional = true, default-features = false }

--- a/programs/pod-com/src/lib.rs
+++ b/programs/pod-com/src/lib.rs
@@ -7,7 +7,7 @@ use anchor_lang::solana_program::pubkey::Pubkey;
 // Light Protocol ZK Compression imports
 use light_compressed_token::program::LightCompressedToken;
 use light_system_program::program::LightSystemProgram;
-use light_hasher::LightHasher;
+use light_hasher::{hash_to_bn254_field_size_be, LightHasher};
 
 declare_id!("HEpGLgYsE1kP8aoYKyLFc3JVVrofS7T4zEA6fWBJsZps");
 


### PR DESCRIPTION
### **User description**
## Summary
- bump Light Protocol crates in pod-com
- document new crate versions in zk compression guide
- update import for `hash_to_bn254_field_size_be`

## ZK Compression Impact
- [ ] Uses ZK compression for cost savings
- [ ] Integrates with Light Protocol properly
- [ ] Includes Photon indexer support

## Testing
- `cargo update` *(fails: zeroize version conflict)*

------
https://chatgpt.com/codex/tasks/task_e_6858a14565b4833099abc0f6da71227a


___

### **PR Type**
Other


___

### **Description**
- Bump Light Protocol crates to newer versions

- Update import for `hash_to_bn254_field_size_be` function

- Document new dependency versions in ZK compression guide


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Update light_hasher import statement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

programs/pod-com/src/lib.rs

<li>Add explicit import for <code>hash_to_bn254_field_size_be</code> function from <br><code>light_hasher</code> crate


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/PoD-Protocol/pull/90/files#diff-6fac89918fe52f8d0337b99ba86941d3de77cd44fae89675946102e49106540e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Update Light Protocol crate versions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

programs/pod-com/Cargo.toml

<li>Bump light-compressed-token from 1.1.0 to 2.0.0<br> <li> Bump light-system-program from 1.1.0 to 1.2.0<br> <li> Bump light-hasher from 1.1.0 to 3.1.0<br> <li> Bump light-heap from 1.1.0 to 2.0.0


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/PoD-Protocol/pull/90/files#diff-744eb7ea4994c1711f92c7096de251b8418841420a21327ff5e4155bd27414ea">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ZK-COMPRESSION-README.md</strong><dd><code>Update dependency versions in documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/guides/ZK-COMPRESSION-README.md

<li>Update Light Protocol dependency versions in documentation<br> <li> Bump light-compressed-token from 1.0.0 to 2.0.0<br> <li> Bump light-system-program from 1.0.0 to 1.2.0<br> <li> Bump light-hasher from 1.0.0 to 3.1.0<br> <li> Bump light-utils from 1.0.0 to 1.1.0


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/PoD-Protocol/pull/90/files#diff-a62b4bafbb6b03b034039626f515085f62461ef2488b9824e13382042c3341c0">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>