### PR TITLE
fix(sdk): align content hash with Rust

### DIFF
--- a/sdk/src/services/ipfs.js
+++ b/sdk/src/services/ipfs.js
@@ -1,7 +1,6 @@
 import { create } from 'ipfs-http-client';
 import { CID } from 'multiformats/cid';
 import { BaseService } from './base.js';
-import { createHash } from 'crypto';
 import keccak from 'keccak';
 /**
  * IPFS Service for handling off-chain storage of PoD Protocol data
@@ -189,14 +188,9 @@ export class IPFSService extends BaseService {
      * Matches the Rust program's hash_to_bn254_field_size_be function
      */
     static createContentHash(content) {
-        // Use SHA-256 to match the Rust program's initial hashing step
-        const sha256Hash = createHash('sha256').update(content, 'utf8').digest();
-        // Emulate hash_to_bn254_field_size_be by hashing the SHA-256 digest with
-        // Keccak256 and forcing the result into the BN254 field
         const keccakHash = keccak('keccak256')
-            .update(Buffer.concat([sha256Hash, Buffer.from([0xff])]))
+            .update(Buffer.concat([Buffer.from(content, 'utf8'), Buffer.from([0xff])]))
             .digest();
-        // Zero out the first byte to ensure the value fits within the field size
         keccakHash[0] = 0;
         return keccakHash.toString('hex');
     }

--- a/sdk/src/services/ipfs.ts
+++ b/sdk/src/services/ipfs.ts
@@ -1,7 +1,6 @@
 import { create, IPFSHTTPClient } from 'ipfs-http-client';
 import { CID } from 'multiformats/cid';
 import { BaseService, BaseServiceConfig } from './base.js';
-import { createHash } from 'crypto';
 import keccak from 'keccak';
 
 /**
@@ -271,16 +270,10 @@ export class IPFSService extends BaseService {
    * Matches the Rust program's hash_to_bn254_field_size_be function
    */
   static createContentHash(content: string): string {
-    // Use SHA-256 to match the Rust program's initial hashing step
-    const sha256Hash = createHash('sha256').update(content, 'utf8').digest();
-
-    // Emulate hash_to_bn254_field_size_be by hashing the SHA-256 digest with
-    // Keccak256 and forcing the result into the BN254 field
     const keccakHash = keccak('keccak256')
-      .update(Buffer.concat([sha256Hash, Buffer.from([0xff])]))
+      .update(Buffer.concat([Buffer.from(content, 'utf8'), Buffer.from([0xff])]))
       .digest();
 
-    // Create a copy and zero out the first byte to ensure the value fits within the BN254 field size
     const fieldSizedHash = Buffer.from(keccakHash);
     fieldSizedHash[0] = 0;
     return fieldSizedHash.toString('hex');

--- a/tests/ipfs-hash.test.ts
+++ b/tests/ipfs-hash.test.ts
@@ -3,9 +3,9 @@ import { IPFSService } from "../sdk/src/services/ipfs";
 
 describe("createContentHash", () => {
   const cases: Record<string, string> = {
-    "hello world": "00349039aa3bd06b0338e1be1d77518829f87fad274590292e429d3044d77ae6",
-    OpenAI: "0013c7c3b8381fb6be3c606d36e405feb27b6c40b1cce031e98488d9805d7c95",
-    "": "00d1b34cbc802b9502833221dc0af4557a24240067a7e78bd2fae2efb617a39b",
+    "hello world": "001e332a8d817b5fb3b49af17074488b700c13e2d2611e4aaec24704bcc6c60c",
+    OpenAI: "002f5def325e554d0601b6a3fcb788ae8f071f39ef85baae22c27e11046a4202",
+    "": "001a944cf13a9a1c08facb2c9e98623ef3254d2ddb48113885c3e8e97fec8db9",
   };
 
   for (const [input, expected] of Object.entries(cases)) {


### PR DESCRIPTION
### **User description**
## Summary
Sync IPFS content hashing with the Rust implementation. `createContentHash` now mirrors `hash_to_bn254_field_size_be` by hashing the UTF‑8 bytes directly with Keccak and zeroing the first byte. Updated unit test verifies equality with the Rust hash values.

## ZK Compression Impact
- [ ] Uses ZK compression for cost savings
- [ ] Integrates with Light Protocol properly
- [ ] Includes Photon indexer support

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests pass
- [ ] Manual testing completed

## Breaking Changes
None

------
https://chatgpt.com/codex/tasks/task_e_6858ae9fc4d0833099fa01e1bba40f1e


___

### **PR Type**
Bug fix


___

### **Description**
- Simplified content hash algorithm to match Rust implementation

- Removed SHA-256 pre-hashing step, now hashes UTF-8 bytes directly

- Updated test cases with correct hash values

- Removed crypto dependency import


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ipfs.ts</strong><dd><code>Simplified content hash algorithm</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sdk/src/services/ipfs.ts

<li>Removed SHA-256 pre-hashing step from <code>createContentHash</code> method<br> <li> Now hashes UTF-8 bytes directly with Keccak256<br> <li> Removed <code>createHash</code> import from crypto module<br> <li> Simplified hash generation to match Rust <code>hash_to_bn254_field_size_be</code>


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/PoD-Protocol/pull/105/files#diff-6e405f46f987cc53769636e1af11d5462470cb6f64496577c53eeeeb81a073e4">+1/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ipfs.js</strong><dd><code>Simplified content hash algorithm</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sdk/src/services/ipfs.js

<li>Removed SHA-256 pre-hashing step from <code>createContentHash</code> method<br> <li> Now hashes UTF-8 bytes directly with Keccak256<br> <li> Removed <code>createHash</code> import from crypto module<br> <li> Simplified buffer handling for field size constraint


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/PoD-Protocol/pull/105/files#diff-67f61a689fcc351a2090a48287f1e3423e6d11994a73eb4f6237c13e3010d8dc">+1/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ipfs-hash.test.ts</strong><dd><code>Updated test hash values</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/ipfs-hash.test.ts

<li>Updated expected hash values for test cases<br> <li> Changed hashes for "hello world", "OpenAI", and empty string<br> <li> Test cases now verify alignment with Rust implementation


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/PoD-Protocol/pull/105/files#diff-2752340af1aece9753ca7fba2f882e970d5c48be1e58d3ef173e880ebeee56b3">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated content hash generation to improve consistency by removing an extra hashing step.
- **Tests**
  - Adjusted test cases to reflect the new expected hash values for various input strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->