### PR TITLE
feat(zk): add compressed token mint config

### DIFF
--- a/cli/src/utils/client.ts
+++ b/cli/src/utils/client.ts
@@ -38,6 +38,9 @@ export async function createClient(
       accountCompressionProgram: process.env.LIGHT_ACCOUNT_COMPRESSION_PROGRAM
         ? new PublicKey(process.env.LIGHT_ACCOUNT_COMPRESSION_PROGRAM)
         : undefined,
+      compressedTokenMint: process.env.LIGHT_COMPRESSED_TOKEN_MINT
+        ? new PublicKey(process.env.LIGHT_COMPRESSED_TOKEN_MINT)
+        : undefined,
     },
   });
   await client.initialize(wallet);

--- a/sdk/src/services/zk-compression.ts
+++ b/sdk/src/services/zk-compression.ts
@@ -60,6 +60,8 @@ export interface ZKCompressionConfig {
   cpiAuthorityPda?: PublicKey;
   /** Compressed Token program */
   compressedTokenProgram?: PublicKey;
+  /** Compressed Token mint */
+  compressedTokenMint?: PublicKey;
   /** Registered Program ID */
   registeredProgramId?: PublicKey;
   /** No-op Program */
@@ -190,6 +192,11 @@ export class ZKCompressionService extends BaseService {
         (process.env.LIGHT_ACCOUNT_COMPRESSION_PROGRAM
           ? new PublicKey(process.env.LIGHT_ACCOUNT_COMPRESSION_PROGRAM)
           : new PublicKey("cmtDvXumGCrqC1Age74AVPhSRVXJMd8PJS91L8KbNCK")),
+      compressedTokenMint:
+        zkConfig.compressedTokenMint ||
+        (process.env.LIGHT_COMPRESSED_TOKEN_MINT
+          ? new PublicKey(process.env.LIGHT_COMPRESSED_TOKEN_MINT)
+          : new PublicKey("jLW99oqPBQx7A3DjwzC6BTgy6o3DQ6mrWprNUbQbTkP")),
     };
 
     this.rpc = createRpc(

--- a/sdk/src/test/zk-compression.test.ts
+++ b/sdk/src/test/zk-compression.test.ts
@@ -18,7 +18,11 @@ describe("ZKCompressionService", () => {
   } as any;
   const ipfs = new IPFSService(baseConfig, {});
 
-  const service = new ZKCompressionService(baseConfig, {}, ipfs);
+  const service = new ZKCompressionService(
+    baseConfig,
+    { compressedTokenMint: Keypair.generate().publicKey },
+    ipfs,
+  );
   (service as any).rpc = new MockRpc();
   // Use jest.spyOn or similar approach to mock without modifying the original
   const compressSpy = jest.spyOn(CompressedTokenProgram, 'compress')


### PR DESCRIPTION
## Summary
- extend `ZKCompressionConfig` with `compressedTokenMint`
- provide default mint address in service constructor
- include the new option when creating a client and in tests

## ZK Compression Impact
- [x] Uses ZK compression for cost savings
- [x] Integrates with Light Protocol properly
- [ ] Includes Photon indexer support

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests pass
- [ ] Manual testing completed

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6858aebbd72883308b99c26b353c9a17