### PR TITLE
feat(zk): integrate Photon indexer client

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -64,6 +64,7 @@
     "@coral-xyz/anchor-cli": "0.31.1",
     "@pod-protocol/sdk": "^1.2.0",
     "@solana/web3.js": "^1.95.4",
+    "@lightprotocol/photon-client": "^0.1.0",
     "chalk": "^5.3.0",
     "commander": "^14.0.0",
     "inquirer": "^12.0.0",

--- a/cli/src/commands/zk-compression.ts
+++ b/cli/src/commands/zk-compression.ts
@@ -10,6 +10,7 @@ import { displayError } from '../utils/error-handler.js';
 import { outputFormatter } from '../utils/output-formatter.js';
 import { validatePublicKey } from '../utils/validation.js';
 import { findAgentPDA } from '@pod-protocol/sdk';
+import { PhotonIndexerClient } from '@lightprotocol/photon-client';
 
 export function createZKCompressionCommand(): Command {
   const zk = new Command('zk')
@@ -443,18 +444,14 @@ export function createZKCompressionCommand(): Command {
       try {
         if (options.test) {
           console.log('🔍 Testing indexer connection...');
-          
-          const response = await fetch(`${options.url}/health`);
-          if (response.ok) {
-            const health = await response.json();
-            outputFormatter.success('Indexer connection successful', {
-              url: options.url,
-              status: health,
-              version: health.version || 'unknown'
-            });
-          } else {
-            throw new Error(`Indexer returned ${response.status}: ${response.statusText}`);
-          }
+
+          const client = new PhotonIndexerClient({ endpoint: options.url });
+          const health = await client.getHealth();
+          outputFormatter.success('Indexer connection successful', {
+            url: options.url,
+            status: health,
+            version: health.version || 'unknown'
+          });
         } else {
           outputFormatter.info('Indexer configuration', {
             current_url: options.url,

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -69,6 +69,7 @@
     "@lightprotocol/stateless.js": "^0.22.0",
     "@solana/web3.js": "^1.95.4",
     "@solana/wallet-adapter-base": "^0.9.27",
+    "@lightprotocol/photon-client": "^0.1.0",
     "ipfs-http-client": "^60.0.1",
     "multiformats": "^13.1.0"
   },

--- a/sdk/src/services/zk-compression.ts
+++ b/sdk/src/services/zk-compression.ts
@@ -5,6 +5,7 @@ import { Transaction, TransactionInstruction, PublicKey, Connection } from '@sol
 
 import { createRpc, LightSystemProgram, Rpc } from '@lightprotocol/stateless.js';
 import { createMint, mintTo, transfer, CompressedTokenProgram } from '@lightprotocol/compressed-token';
+import { PhotonIndexerClient, PhotonIndexerClientOptions } from '@lightprotocol/photon-client';
 
 /**
  * Compressed account information returned by Light Protocol
@@ -44,6 +45,8 @@ export interface ZKCompressionConfig {
   proverUrl?: string;
   /** Photon indexer endpoint */
   photonIndexerUrl?: string;
+  /** Photon indexer client options */
+  photonIndexerClientOptions?: PhotonIndexerClientOptions;
   /** Maximum batch size for compression operations */
   maxBatchSize?: number;
   /** Batch size (alias for maxBatchSize) */
@@ -112,6 +115,7 @@ export interface BatchSyncOperation {
 export class ZKCompressionService extends BaseService {
   private config: ZKCompressionConfig;
   private rpc: Rpc;
+  private indexer: PhotonIndexerClient;
   private ipfsService: IPFSService;
   private batchQueue: CompressedChannelMessage[] = [];
   private batchTimer?: NodeJS.Timeout;
@@ -146,6 +150,8 @@ export class ZKCompressionService extends BaseService {
         zkConfig.photonIndexerUrl ||
         process.env.PHOTON_INDEXER_URL ||
         "http://localhost:8080",
+      photonIndexerClientOptions:
+        zkConfig.photonIndexerClientOptions,
       maxBatchSize: zkConfig.maxBatchSize || 50,
       enableBatching: zkConfig.enableBatching ?? true,
       batchTimeout: zkConfig.batchTimeout || 5000,
@@ -196,6 +202,12 @@ export class ZKCompressionService extends BaseService {
       this.config.lightRpcUrl,
       this.config.compressionRpcUrl, // Use compression endpoint
       this.config.proverUrl  // Use prover endpoint
+    );
+
+    this.indexer = new PhotonIndexerClient(
+      this.config.photonIndexerClientOptions ?? {
+        endpoint: this.config.photonIndexerUrl,
+      },
     );
 
     this.ipfsService = ipfsService;
@@ -466,34 +478,17 @@ export class ZKCompressionService extends BaseService {
     } = {}
   ): Promise<CompressedChannelMessage[]> {
     try {
-      // Query compressed messages via Photon indexer JSON-RPC
-      const rpcReq = {
-        jsonrpc: '2.0',
-        id: Date.now(),
-        method: 'getCompressedMessagesByChannel',
-        params: [
-          channelId.toString(),
-          options.limit ?? 50,
-          options.offset ?? 0,
-          options.sender?.toString() || null,
-          options.after?.getTime() || null,
-          options.before?.getTime() || null,
-        ],
-      };
-      const response = await fetch(this.config.photonIndexerUrl!, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(rpcReq),
-      });
-      if (!response.ok) {
-        throw new Error(`Indexer RPC failed: ${response.statusText}`);
-      }
-      const json = await response.json() as { result?: any[], error?: { message?: string } };
-      if (json.error) {
-        throw new Error(`Indexer RPC error: ${json.error?.message || 'Unknown error'}`);
-      }
-      const raw = json.result || [];
-      return raw.map(m => ({
+      const raw = await this.indexer.getCompressedMessagesByChannel(
+        channelId.toString(),
+        {
+          limit: options.limit ?? 50,
+          offset: options.offset ?? 0,
+          sender: options.sender?.toString(),
+          after: options.after?.getTime(),
+          before: options.before?.getTime(),
+        },
+      );
+      return raw.map((m: any) => ({
         channel: new PublicKey(m.channel),
         sender: new PublicKey(m.sender),
         contentHash: m.content_hash,
@@ -518,20 +513,12 @@ export class ZKCompressionService extends BaseService {
     compressionRatio: number;
   }> {
     try {
-      const response = await fetch(
-        `${this.config.photonIndexerUrl}/channel-stats/${channelId.toString()}`
-      );
-
-      if (!response.ok) {
-        throw new Error(`Stats query failed: ${response.statusText}`);
-      }
-
-      const data = await response.json() as any;
+      const data = await this.indexer.getChannelStats(channelId.toString());
       return {
         totalMessages: data.totalMessages || 0,
         totalParticipants: data.totalParticipants || 0,
         storageSize: data.storageSize || 0,
-        compressionRatio: data.compressionRatio || 1.0
+        compressionRatio: data.compressionRatio || 1.0,
       };
     } catch (error) {
       throw new Error(`Failed to get channel stats: ${error}`);


### PR DESCRIPTION
### **User description**
## Summary
- use Photon indexer client in ZK compression service
- expose Photon client options in config
- update CLI indexer test command

## ZK Compression Impact
- [x] Uses ZK compression for cost savings
- [x] Integrates with Light Protocol properly
- [x] Includes Photon indexer support

## Testing
- `bun test` *(fails: Cannot find package 'ipfs-http-client' and others)*


------
https://chatgpt.com/codex/tasks/task_e_6858aec35a208330afd7b82074bf42ba


___

### **PR Type**
Enhancement


___

### **Description**
- Replace manual HTTP requests with Photon indexer client

- Add Photon client configuration options to ZK compression service

- Update CLI indexer test command to use client

- Add Photon client dependency to both CLI and SDK packages


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>zk-compression.ts</strong><dd><code>Replace manual HTTP with Photon client in CLI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/src/commands/zk-compression.ts

<li>Import <code>PhotonIndexerClient</code> from <code>@lightprotocol/photon-client</code><br> <li> Replace manual fetch request with client's <code>getHealth()</code> method<br> <li> Simplify indexer connection testing logic


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/PoD-Protocol/pull/113/files#diff-33dd7d2d4b8056ab79c320603d5329af2675c04281881fae56467724771b7eab">+9/-12</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>zk-compression.ts</strong><dd><code>Integrate Photon client in ZK compression service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sdk/src/services/zk-compression.ts

<li>Import <code>PhotonIndexerClient</code> and <code>PhotonIndexerClientOptions</code><br> <li> Add <code>photonIndexerClientOptions</code> to <code>ZKCompressionConfig</code> interface<br> <li> Initialize <code>PhotonIndexerClient</code> instance in constructor<br> <li> Replace manual JSON-RPC calls with client methods in <br><code>getCompressedMessages()</code> and <code>getChannelStats()</code>


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/PoD-Protocol/pull/113/files#diff-767cb26cf89e21edd94e3f0a20007ecc60f3f583dd7810dc959b26b7da8129b9">+25/-38</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add Photon client dependency to CLI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/package.json

- Add `@lightprotocol/photon-client` version `^0.1.0` dependency


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/PoD-Protocol/pull/113/files#diff-088b5e0ac52dd36816ebc6b121d5423c763c3c18c098b91757c014937c7d632d">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add Photon client dependency to SDK</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sdk/package.json

- Add `@lightprotocol/photon-client` version `^0.1.0` dependency


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/PoD-Protocol/pull/113/files#diff-bc6c710dd83d0c2c292ae9ad22e2de397afdc872d5f6efa8c034785ede082613">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>