### PR TITLE
feat(cli): configurable indexer endpoint

### DIFF
--- a/cli/src/commands/zk-compression.ts
+++ b/cli/src/commands/zk-compression.ts
@@ -437,7 +437,11 @@ export function createZKCompressionCommand(): Command {
   configCmd
     .command('indexer')
     .description('Configure Photon indexer connection')
-    .option('--url <url>', 'Indexer API URL', 'http://localhost:8080')
+    .option(
+      '--url <url>',
+      'Indexer API URL',
+      process.env.PHOTON_INDEXER_URL || 'https://mainnet.helius-rpc.com'
+    )
     .option('--test', 'Test indexer connection')
     .action(async (options) => {
       try {

--- a/docs/guides/ENVIRONMENT_CONFIG.md
+++ b/docs/guides/ENVIRONMENT_CONFIG.md
@@ -213,6 +213,9 @@ echo "PHOTON_INDEXER_URL=https://devnet.helius-rpc.com" >> .env
 echo "ENABLE_ZK_COMPRESSION=true" >> .env
 ```
 
+Set `PHOTON_INDEXER_URL` to the URL of your Photon indexer. If this variable is
+not set, the CLI falls back to `https://mainnet.helius-rpc.com`.
+
 ### Custom Light Protocol Addresses
 
 You can override the default Light Protocol RPC URLs and program IDs using environment variables:

--- a/docs/guides/GETTING_STARTED.md
+++ b/docs/guides/GETTING_STARTED.md
@@ -44,6 +44,8 @@ solana airdrop 2   # Get some SOL for testing
 ```bash
 cp .env.example .env
 # Edit .env with your preferred settings
+# Set PHOTON_INDEXER_URL to your Photon indexer endpoint
+# (defaults to https://mainnet.helius-rpc.com if unset)
 ```
 
 ## Basic Usage


### PR DESCRIPTION
### **User description**
## Summary
- allow `pod zk config indexer` to use `PHOTON_INDEXER_URL` env var
- document how to set the Photon indexer URL

## ZK Compression Impact
- [ ] Uses ZK compression for cost savings
- [ ] Integrates with Light Protocol properly
- [ ] Includes Photon indexer support

## Testing
- `yarn run test` *(fails: Unrecognized configuration)*
- `npm test` *(fails: missing dependencies)*


------
https://chatgpt.com/codex/tasks/task_e_6859281301988330b908130516b07f59


___

### **PR Type**
Enhancement


___

### **Description**
- Make indexer URL configurable via `PHOTON_INDEXER_URL` environment variable

- Update default indexer URL from localhost to Helius mainnet

- Add documentation for indexer URL configuration


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>zk-compression.ts</strong><dd><code>Add environment variable support for indexer URL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/src/commands/zk-compression.ts

<li>Replace hardcoded localhost URL with environment variable support<br> <li> Set default to <code>https://mainnet.helius-rpc.com</code> when env var not set<br> <li> Use <code>process.env.PHOTON_INDEXER_URL</code> as primary configuration source


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/PoD-Protocol/pull/124/files#diff-33dd7d2d4b8056ab79c320603d5329af2675c04281881fae56467724771b7eab">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ENVIRONMENT_CONFIG.md</strong><dd><code>Document indexer URL environment configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/guides/ENVIRONMENT_CONFIG.md

<li>Document <code>PHOTON_INDEXER_URL</code> environment variable usage<br> <li> Explain fallback behavior to mainnet Helius RPC


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/PoD-Protocol/pull/124/files#diff-021dd40eea2a336309c89a260ccc88065f7bcaab91d418419d9aaf364d208e7e">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>GETTING_STARTED.md</strong><dd><code>Add indexer URL setup instructions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/guides/GETTING_STARTED.md

<li>Add comment about setting <code>PHOTON_INDEXER_URL</code> in .env file<br> <li> Mention default fallback URL behavior


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/PoD-Protocol/pull/124/files#diff-a534e8b09e1d26d4ddd3750d92748184bc3bfbd68f1d42fd861e1d3d17f61b96">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>