### PR TITLE
feat(cli): allow custom participant for zk join

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,10 @@ pod channel join <channel-id>
 pod zk message broadcast <channel-id> "Hello compressed world!"
 
 # Join a channel with compressed participant data
-pod zk participant join <channel-id> --name "AgentX" --avatar "avatar.png"
-# The agent PDA is derived automatically from your wallet keypair
+pod zk participant join <channel-id> \
+  --name "AgentX" --avatar "avatar.png" \
+  --participant <custom-pubkey>
+# Omit --participant to use the PDA derived from your wallet
 
 # Batch-sync compressed messages to chain
 pod zk batch sync <channel-id> <hash1> <hash2> <hash3>

--- a/cli/src/commands/zk-compression.ts
+++ b/cli/src/commands/zk-compression.ts
@@ -218,6 +218,10 @@ export function createZKCompressionCommand(): Command {
     .option('-n, --name <name>', 'Display name')
     .option('-a, --avatar <url>', 'Avatar URL')
     .option('-p, --permissions <perms...>', 'Permissions list')
+    .option(
+      '-P, --participant <pubkey>',
+      'Custom participant public key (defaults to wallet PDA)',
+    )
     .action(async (channelId, options) => {
       try {
         const wallet = getWallet(options.keypair);
@@ -228,7 +232,16 @@ export function createZKCompressionCommand(): Command {
         }
 
         const channel = new PublicKey(channelId);
-        const [participant] = findAgentPDA(wallet.publicKey);
+        let participant: PublicKey;
+
+        if (options.participant) {
+          if (!validatePublicKey(options.participant)) {
+            throw new Error('Invalid participant public key');
+          }
+          participant = new PublicKey(options.participant);
+        } else {
+          [participant] = findAgentPDA(wallet.publicKey);
+        }
         
         console.log('🤝 Joining channel with compression...');
         

--- a/cli/src/test/cli-commands.test.ts
+++ b/cli/src/test/cli-commands.test.ts
@@ -119,4 +119,17 @@ describe("CLI Command Tests", () => {
     expect(res.exitCode).toBe(0);
     expect(res.stdout).toContain("PoD Protocol Status");
   });
+
+  it("zk participant join with custom key validation", async () => {
+    const res = await runCli([
+      "zk",
+      "participant",
+      "join",
+      "11111111111111111111111111111111111111111111",
+      "--participant",
+      "invalidKey",
+    ]);
+    expect(res.exitCode).not.toBe(0);
+    expect(res.stderr).toContain("Invalid participant public key");
+  });
 });

--- a/docs/guides/ZK-COMPRESSION-README.md
+++ b/docs/guides/ZK-COMPRESSION-README.md
@@ -102,8 +102,9 @@ pod zk message query <channel> --limit 50 --verify-content
 pod zk message content <ipfs-hash> --verify-hash <on-chain-hash>
 
 # Participant operations
-pod zk participant join <channel> --name "AI Agent" --avatar "avatar.png"
-# The agent PDA is automatically derived from your wallet
+pod zk participant join <channel> --name "AI Agent" \
+  --avatar "avatar.png" --participant <custom-pubkey>
+# Omit --participant to join with your wallet-derived PDA
 
 # Batch operations
 pod zk batch sync <channel> <hash1> <hash2> ... <hashN>


### PR DESCRIPTION
### **User description**
## Summary
- add `--participant` option for `zk participant join`
- validate provided public key and fall back to the wallet PDA
- document the participant flag in README and ZK Compression guide
- cover custom participant validation in CLI tests

## ZK Compression Impact
- [ ] Uses ZK compression for cost savings
- [ ] Integrates with Light Protocol properly
- [ ] Includes Photon indexer support

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests pass
- [ ] Manual testing completed

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

## Breaking Changes
- none

------
https://chatgpt.com/codex/tasks/task_e_685927dcaddc8330906a4325891817c6


___

### **PR Type**
Enhancement


___

### **Description**
- Add `--participant` option to `zk participant join` command

- Validate custom participant public key with fallback to wallet PDA

- Update documentation with new participant flag usage

- Add CLI test for custom participant key validation


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>zk-compression.ts</strong><dd><code>Add custom participant option with validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/src/commands/zk-compression.ts

<li>Add <code>--participant</code> option to join command<br> <li> Implement public key validation for custom participant<br> <li> Fallback to wallet PDA when no custom participant provided


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/PoD-Protocol/pull/127/files#diff-33dd7d2d4b8056ab79c320603d5329af2675c04281881fae56467724771b7eab">+14/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cli-commands.test.ts</strong><dd><code>Add participant validation test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/src/test/cli-commands.test.ts

<li>Add test for invalid participant public key validation<br> <li> Verify error handling for malformed participant keys


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/PoD-Protocol/pull/127/files#diff-a58e4acd425b23c5d37c6937bb8d55634a1332a3448e00e82fc902caf9565ae2">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update CLI documentation for participant option</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<li>Update <code>zk participant join</code> command example<br> <li> Document <code>--participant</code> flag usage and fallback behavior


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/PoD-Protocol/pull/127/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ZK-COMPRESSION-README.md</strong><dd><code>Update ZK compression guide documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/guides/ZK-COMPRESSION-README.md

<li>Update participant join command documentation<br> <li> Clarify custom participant vs wallet PDA usage


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/PoD-Protocol/pull/127/files#diff-a62b4bafbb6b03b034039626f515085f62461ef2488b9824e13382042c3341c0">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>