### PR TITLE
fix(sdk): return merkle root for batched messages

### DIFF
--- a/sdk/src/services/zk-compression.ts
+++ b/sdk/src/services/zk-compression.ts
@@ -2,6 +2,7 @@ import { AnchorProvider } from '@coral-xyz/anchor';
 import { BaseService, BaseServiceConfig } from './base.js';
 import { IPFSService, IPFSStorageResult } from './ipfs.js';
 import { Transaction, TransactionInstruction, PublicKey, Connection } from '@solana/web3.js';
+import { createHash } from 'crypto';
 
 import { createRpc, LightSystemProgram, Rpc } from '@lightprotocol/stateless.js';
 import { createMint, mintTo, transfer, CompressedTokenProgram } from '@lightprotocol/compressed-token';
@@ -705,13 +706,17 @@ export class ZKCompressionService extends BaseService {
         throw new Error(`Light Protocol RPC error: ${err}`);
       }
 
+      const hashes = batch.map((m) => Buffer.from(m.contentHash, 'hex'));
+      const { root, proofs } = this.buildMerkleTree(hashes);
+
       const result = {
         signature,
-        compressedAccounts: batch.map((msg) => ({
+        compressedAccounts: batch.map((msg, i) => ({
           hash: msg.contentHash,
           data: msg,
+          merkleContext: { proof: proofs[i], index: i },
         })),
-        merkleRoot: '',
+        merkleRoot: root,
       };
 
       this.lastBatchResult = {
@@ -758,6 +763,49 @@ export class ZKCompressionService extends BaseService {
       lamports: 0,
       outputStateTreeInfo: treeInfo,
     });
+  }
+
+  /**
+   * Private: Compute Merkle root and proofs for a list of hashes
+   */
+  private buildMerkleTree(hashes: Buffer[]): { root: string; proofs: string[][] } {
+    if (hashes.length === 0) {
+      return { root: '', proofs: [] };
+    }
+
+    const levels: Buffer[][] = [hashes];
+
+    while (levels[levels.length - 1].length > 1) {
+      const prev = levels[levels.length - 1];
+      const next: Buffer[] = [];
+      for (let i = 0; i < prev.length; i += 2) {
+        const left = prev[i];
+        const right = prev[i + 1] || left;
+        const hash = createHash('sha256')
+          .update(Buffer.concat([left, right]))
+          .digest();
+        next.push(hash);
+      }
+      levels.push(next);
+    }
+
+    const root = levels[levels.length - 1][0].toString('hex');
+    const proofs: string[][] = [];
+
+    for (let i = 0; i < hashes.length; i++) {
+      let index = i;
+      const proof: string[] = [];
+      for (let level = 0; level < levels.length - 1; level++) {
+        const nodes = levels[level];
+        const siblingIndex = index % 2 === 0 ? index + 1 : index - 1;
+        const sibling = nodes[siblingIndex] ?? nodes[index];
+        proof.push(sibling.toString('hex'));
+        index = Math.floor(index / 2);
+      }
+      proofs.push(proof);
+    }
+
+    return { root, proofs };
   }
 
   /**

--- a/tests/merkle-tree.test.ts
+++ b/tests/merkle-tree.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "bun:test";
+import { Connection, PublicKey } from "@solana/web3.js";
+import { createHash } from "crypto";
+import { IPFSService } from "../sdk/src/services/ipfs";
+import { ZKCompressionService } from "../sdk/src/services/zk-compression";
+import { BaseServiceConfig } from "../sdk/src/services/base";
+
+const baseConfig: BaseServiceConfig = {
+  connection: new Connection("http://localhost:8899"),
+  programId: new PublicKey("11111111111111111111111111111111"),
+  commitment: "confirmed" as any,
+};
+
+const ipfs = new IPFSService(baseConfig);
+const zk = new ZKCompressionService(baseConfig, { enableBatching: false }, ipfs);
+
+function sha256Hex(data: string): string {
+  return createHash("sha256").update(data).digest("hex");
+}
+
+test("buildMerkleTree computes correct root", () => {
+  const msgs = ["hello", "world", "test"];
+  const hashes = msgs.map(sha256Hex).map((h) => Buffer.from(h, "hex"));
+  const { root } = (zk as any).buildMerkleTree(hashes);
+  expect(root).toBe(
+    "51f8ef61c28fbe2a9d67319302117104259d46a16a69f5b8fffeb9b5b70abada"
+  );
+});


### PR DESCRIPTION
## Summary
- compute merkle root and proofs when batching
- expose merkle tree building logic via new helper
- add unit test for merkle tree calculation

## ZK Compression Impact
- [x] Uses ZK compression for cost savings
- [ ] Integrates with Light Protocol properly
- [ ] Includes Photon indexer support

## Testing
- `bun test` *(fails: Cannot find module '@coral-xyz/anchor')*


------
https://chatgpt.com/codex/tasks/task_e_685928237bb08330a0366a17dffe8bd0