### PR TITLE
fix(frontend): improve navigation and accessibility

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -271,8 +271,8 @@ const Dashboard = () => {
                 };
                 
                 return (
-                  <motion.div 
-                    key={index} 
+                  <motion.div
+                    key={activity.action}
                     initial={{ opacity: 0, x: -20 }}
                     animate={{ opacity: 1, x: 0 }}
                     transition={{ delay: index * 0.1 }}

--- a/frontend/src/app/messages/page.tsx
+++ b/frontend/src/app/messages/page.tsx
@@ -163,7 +163,7 @@ export default function MessagesPage() {
     setNewMessage("");
   };
 
-  const handleKeyPress = (e: React.KeyboardEvent) => {
+  const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       handleSendMessage();
@@ -192,11 +192,12 @@ export default function MessagesPage() {
           {/* Conversations List */}
           <div className="flex-1 overflow-y-auto">
             {filteredConversations.map((conv) => (
-              <motion.div
+              <motion.button
                 key={conv.agent.id}
+                type="button"
                 whileHover={{ backgroundColor: "rgba(139, 92, 246, 0.1)" }}
                 onClick={() => setSelectedAgent(conv.agent)}
-                className={`p-4 cursor-pointer border-b border-purple-500/10 transition-colors ${
+                className={`w-full text-left p-4 cursor-pointer border-b border-purple-500/10 transition-colors ${
                   selectedAgent?.id === conv.agent.id ? "bg-purple-500/20" : ""
                 }`}
               >
@@ -226,7 +227,7 @@ export default function MessagesPage() {
                     </p>
                   </div>
                 </div>
-              </motion.div>
+              </motion.button>
             ))}
           </div>
         </div>
@@ -305,7 +306,7 @@ export default function MessagesPage() {
                     <textarea
                       value={newMessage}
                       onChange={(e) => setNewMessage(e.target.value)}
-                      onKeyPress={handleKeyPress}
+                      onKeyDown={handleKeyDown}
                       placeholder="Type a message..."
                       rows={1}
                       className="w-full px-4 py-2 bg-purple-900/20 border border-purple-500/30 rounded-lg text-white placeholder-purple-300 focus:outline-none focus:ring-2 focus:ring-purple-500 resize-none"

--- a/frontend/src/components/layout/DashboardLayout.tsx
+++ b/frontend/src/components/layout/DashboardLayout.tsx
@@ -15,6 +15,7 @@ import {
 import { WalletMultiButton } from '@solana/wallet-adapter-react-ui';
 import useStore from '../store/useStore';
 import MatrixRain from '../ui/MatrixRain';
+import Link from 'next/link';
 
 interface DashboardLayoutProps {
   children: ReactNode;
@@ -70,7 +71,7 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children }) => {
           {/* Navigation */}
           <nav className="flex-1 px-4 py-4 space-y-2">
             {navigation.map((item) => (
-              <a
+              <Link
                 key={item.name}
                 href={item.href}
                 className={`
@@ -93,7 +94,7 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children }) => {
                     </motion.span>
                   )}
                 </AnimatePresence>
-              </a>
+              </Link>
             ))}
           </nav>
           
@@ -158,6 +159,7 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children }) => {
                 <input
                   type="text"
                   placeholder="Search agents, channels..."
+                  aria-label="Search agents and channels"
                   className="
                     pl-10 pr-4 py-2 w-64
                     bg-gray-800/50 border border-purple-500/20
@@ -171,7 +173,10 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children }) => {
             
             <div className="flex items-center space-x-4">
               {/* Notifications */}
-              <button className="relative p-2 text-gray-400 hover:text-white hover:bg-purple-600/20 rounded-lg transition-colors">
+              <button
+                aria-label="Notifications"
+                className="relative p-2 text-gray-400 hover:text-white hover:bg-purple-600/20 rounded-lg transition-colors"
+              >
                 <BellIcon className="h-5 w-5" />
                 {unreadNotifications > 0 && (
                   <span className="absolute -top-1 -right-1 h-4 w-4 bg-red-500 text-white text-xs rounded-full flex items-center justify-center">


### PR DESCRIPTION
## Summary
- use Next.js `<Link>` for sidebar navigation
- add missing aria labels for search and notifications
- make conversation items buttons for accessibility
- update message input to `onKeyDown`
- fix activity list keys

## ZK Compression Impact
- [ ] Uses ZK compression for cost savings
- [ ] Integrates with Light Protocol properly
- [ ] Includes Photon indexer support

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests pass
- [ ] Manual testing completed

## Breaking Changes
- None

------
https://chatgpt.com/codex/tasks/task_e_68594d3a8f64833097f1375f7d3adb33