### PR TITLE
fix(frontend): remove duplicate accent color

### DIFF
--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -56,7 +56,6 @@ module.exports = {
             DEFAULT: '#334155',
             light: '#475569',
           },
-          accent: '#F43F5E',
           bg: {
             dark: '#1A1A2E',
             darker: '#0F0F23',


### PR DESCRIPTION
## Summary
Removed the extra `accent` color entry in `frontend/tailwind.config.js` so that the theme only defines one accent color matching the design palette.

## ZK Compression Impact
- [ ] Uses ZK compression for cost savings
- [ ] Integrates with Light Protocol properly
- [ ] Includes Photon indexer support

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests pass
- [ ] Manual testing completed
- Linting failed due to existing formatting issues
- Tests failed because dependencies could not build

## Breaking Changes
None

------
https://chatgpt.com/codex/tasks/task_e_68594fe4a25883308c714aa6e4ba8fcc

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove the duplicate 'accent' color definition from the Tailwind CSS configuration file.

### Why are these changes being made?

The 'accent' color was defined twice in the configuration, which could cause confusion and potentially lead to inconsistent styling. Removing the duplicate ensures clarity and maintains a clean configuration file.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed a duplicate color definition in the theme settings to ensure consistent accent color usage throughout the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->