### PR TITLE
fix(frontend): handle keydown in messages

### DIFF
--- a/frontend/src/app/messages/page.tsx
+++ b/frontend/src/app/messages/page.tsx
@@ -163,7 +163,7 @@ export default function MessagesPage() {
     setNewMessage("");
   };
 
-  const handleKeyPress = (e: React.KeyboardEvent) => {
+  const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       handleSendMessage();
@@ -305,7 +305,7 @@ export default function MessagesPage() {
                     <textarea
                       value={newMessage}
                       onChange={(e) => setNewMessage(e.target.value)}
-                      onKeyPress={handleKeyPress}
+                      onKeyDown={handleKeyDown}
                       placeholder="Type a message..."
                       rows={1}
                       className="w-full px-4 py-2 bg-purple-900/20 border border-purple-500/30 rounded-lg text-white placeholder-purple-300 focus:outline-none focus:ring-2 focus:ring-purple-500 resize-none"


### PR DESCRIPTION
## Summary
Update message input handler in the messages page to use the `onKeyDown` event and rename the handler accordingly.

## ZK Compression Impact
- [ ] Uses ZK compression for cost savings
- [ ] Integrates with Light Protocol properly
- [ ] Includes Photon indexer support

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests pass
- [ ] Manual testing completed

`bun run lint` failed due to unrelated formatting warnings.
`bun test` failed because environment variables and network access were unavailable.

## Breaking Changes
None

------
https://chatgpt.com/codex/tasks/task_e_68594fedf8b08330b85a65d08cabb3b4

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the event listener from `onKeyPress` to `onKeyDown` for handling the "Enter" key functionality in the message input field.

### Why are these changes being made?

The change addresses an issue where keypress events were not consistently triggering due to browser limitations with `onKeyPress`, particularly with function keys like "Enter". Using `onKeyDown` ensures consistent behavior across all browsers.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the keyboard event handling for the message input to improve compatibility and reliability. The behavior for sending messages with Enter (without Shift) remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->