### PR TITLE
fix(frontend): use router navigation

### DIFF
--- a/frontend/src/app/channels/page.tsx
+++ b/frontend/src/app/channels/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 import { motion, AnimatePresence } from 'framer-motion';
 import { 
   PlusIcon,
@@ -18,6 +19,7 @@ import { Channel, ChannelType } from '../../components/store/types';
 import usePodClient from '../../hooks/usePodClient';
 
 const ChannelsPage = () => {
+  const router = useRouter();
   const { channels, setChannels, setChannelsLoading, setChannelsError, setActiveChannel } = useStore();
   const client = usePodClient();
   const [searchQuery, setSearchQuery] = useState('');
@@ -116,7 +118,7 @@ const ChannelsPage = () => {
   const handleChannelClick = (channelId: string) => {
     setActiveChannel(channelId);
     // Navigate to chat interface
-    window.location.href = `/chat/${channelId}`;
+    router.push(`/chat/${channelId}`);
   };
 
   return (


### PR DESCRIPTION
## Summary
- use next.js router for channel navigation

## ZK Compression Impact
- [ ] Uses ZK compression for cost savings
- [ ] Integrates with Light Protocol properly
- [ ] Includes Photon indexer support

## Testing
- `bun run test` *(fails: failed to select a version for `zeroize`)*

------
https://chatgpt.com/codex/tasks/task_e_68594ffc41208330ab2ab0673f697102